### PR TITLE
package.json: replace prepublish with pretest

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "browserify": "browserify --standalone CleanCSS index.js | uglifyjs --compress --mangle -o cleancss-browser.js",
     "bench": "node ./test/bench.js",
     "check": "jshint .",
-    "prepublish": "npm run check",
+    "pretest": "npm run check",
     "test": "vows"
   },
   "dependencies": {


### PR DESCRIPTION
Prepublish is deprecated and shouldn't be used. I'm not sure if you meant the script to run on `npm i` too, so I went with what makes more sense to me.

On the other hand, we could just run `check` in `test`.