### PR TITLE
Fix local inlining error

### DIFF
--- a/lib/reader/read-sources.js
+++ b/lib/reader/read-sources.js
@@ -294,7 +294,7 @@ function inlineLocalStylesheet(uri, mediaQuery, metadata, inlinerContext) {
 
   if (inlinerContext.inlinedStylesheets.indexOf(absoluteUri) > -1) {
     inlinerContext.warnings.push('Ignoring local @import of "' + uri + '" as it has already been imported.');
-  } else if (!isLoaded && (!fs.existsSync(absoluteUri) || !fs.statSync(absoluteUri).isFile())) {
+  } else if (isAllowed && !isLoaded && (!fs.existsSync(absoluteUri) || !fs.statSync(absoluteUri).isFile())) {
     inlinerContext.errors.push('Ignoring local @import of "' + uri + '" as resource is missing.');
   } else if (!isAllowed && inlinerContext.afterContent) {
     inlinerContext.warnings.push('Ignoring local @import of "' + uri + '" as resource is not allowed and after other content.');


### PR DESCRIPTION
inline=['remote'] is failing when a local file is missing despite the fact that local imports should not be inlined