### PR TITLE
Fixes #1218 - double hyphen in at-rule breaks parsing

### DIFF
--- a/lib/tokenizer/tokenize.js
+++ b/lib/tokenizer/tokenize.js
@@ -373,6 +373,7 @@ function intoTokens(source, externalContext, internalContext, isNested) {
       position.index++;
       buffer = [];
       isBufferEmpty = true;
+      isVariable = false;
 
       ruleToken[2] = intoTokens(source, externalContext, internalContext, true);
       ruleToken = null;


### PR DESCRIPTION
Reset the `isVariable` flag at this point if it's set erroneously.

E.g. `@keyframes Toast--spinner {` — at this point we're certain we aren't a variable.