### PR TITLE
Fixes incorrectly appending '%'s to rgba of numbers

### DIFF
--- a/lib/optimizer/level-1/value-optimizers/color.js
+++ b/lib/optimizer/level-1/value-optimizers/color.js
@@ -54,7 +54,7 @@ var plugin = {
           var applies = (colorFnLowercase == 'hsl' && tokens.length == 3)
             || (colorFnLowercase == 'hsla' && tokens.length == 4)
             || (colorFnLowercase == 'rgb' && tokens.length === 3 && colorDef.indexOf('%') > 0)
-            || (colorFnLowercase == 'rgba' && tokens.length == 4 && colorDef.indexOf('%') > 0);
+            || (colorFnLowercase == 'rgba' && tokens.length == 4 && tokens[0].indexOf('%') > 0);
 
           if (!applies) {
             return match;

--- a/test/optimizer/level-1/optimize-test.js
+++ b/test/optimizer/level-1/optimize-test.js
@@ -410,6 +410,14 @@ vows.describe('level 1 optimizations')
         'a{color:rgba(255,254,253,.5)}',
         'a{color:rgba(255,254,253,.5)}'
       ],
+      'rgba of numbers': [
+        'a{color:rgba(255,255,255,50%)}',
+        'a{color:rgba(255,255,255,50%)}'
+      ],
+      'rgba of percentages': [
+        'a{color:rgba(100%,100%,100%,50%)}',
+        'a{color:rgba(100%,100%,100%,50%)}'
+      ],
       'hsl to hex': [
         'a{color:hsl(240,100%,50%)}',
         'a{color:#00f}'


### PR DESCRIPTION
The Alpha value in rgba can be a percentage, like `50%` which is the same as `.5`.

Given input:
```css
a{color:rgba(255,255,255,50%)}
```

The expected output should be:
```css
a{color:rgba(255,255,255,50%)}
```

While the actual output is:
```css
a{color:rgba(255,255%,255%,50%)}
```

This PR fixes this bug.