### PR TITLE
Set CI workflow permissions; add additional CodeQL queries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: "javascript"
+          queries: "security-and-quality"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ on:
     - cron: "0 2 * * 5"
   workflow_dispatch:
 
+permissions:
+    security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 env:
   FORCE_COLOR: 2
 


### PR DESCRIPTION
Apologies, forgot to add these in previous PR!

This PR:
-   Declares the minimum permissions for CI workflows to run at the job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
    - CodeQL workflow also needs the `security-events` permission set to properly work, see https://github.com/github/codeql-action#usage
-  Adds additional CodeQL security queries, see https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs