### PR TITLE
Fixes #1232 - add support for the "@container" keyword

### DIFF
--- a/lib/tokenizer/tokenize.js
+++ b/lib/tokenizer/tokenize.js
@@ -25,7 +25,8 @@ var BLOCK_RULES = [
   '@-webkit-keyframes',
   '@keyframes',
   '@media',
-  '@supports'
+  '@supports',
+  '@container'
 ];
 
 var IGNORE_END_COMMENT_PATTERN = /\/\* clean-css ignore:end \*\/$/;

--- a/test/fixtures/issue-1232-min.css
+++ b/test/fixtures/issue-1232-min.css
@@ -1,0 +1,3 @@
+@container (min-width:300px){
+.test{font-size:15px;font-weight:700;line-height:10px}
+}

--- a/test/fixtures/issue-1232.css
+++ b/test/fixtures/issue-1232.css
@@ -1,0 +1,7 @@
+@container (min-width:300px) {
+    .test {
+        font-size: 15px;
+        font-weight: bold;
+        line-height: 10px;
+    }
+}


### PR DESCRIPTION
Hi.
I found a solution how to fix the support of the "@container" keyword.
See opened issue here https://github.com/clean-css/clean-css/issues/1232.