### PR TITLE
fix clean-css/clean-css-cli#77

### DIFF
--- a/lib/options/format.js
+++ b/lib/options/format.js
@@ -149,6 +149,8 @@ function toHash(string) {
         accumulator[name] = mapIndentWith(value);
       } else if (name == 'breakWith') {
         accumulator[name] = mapBreakWith(value);
+      } else {
+        accumulator[name] = normalizeValue(value);
       }
 
       return accumulator;

--- a/lib/options/format.js
+++ b/lib/options/format.js
@@ -1,6 +1,7 @@
 var systemLineBreak = require('os').EOL;
 
 var override = require('../utils/override');
+var normalizeValue = require('../utils/normalize-value');
 
 var Breaks = {
   AfterAtRule: 'afterAtRule',
@@ -48,11 +49,6 @@ var OPTION_SEPARATOR = ';';
 var OPTION_NAME_VALUE_SEPARATOR = ':';
 var HASH_VALUES_OPTION_SEPARATOR = ',';
 var HASH_VALUES_NAME_VALUE_SEPARATOR = '=';
-
-var FALSE_KEYWORD_1 = 'false';
-var FALSE_KEYWORD_2 = 'off';
-var TRUE_KEYWORD_1 = 'true';
-var TRUE_KEYWORD_2 = 'on';
 
 function breaks(value) {
   var breakOptions = {};
@@ -169,19 +165,6 @@ function hashValuesToHash(string) {
 
       return accumulator;
     }, {});
-}
-
-function normalizeValue(value) {
-  switch (value) {
-  case FALSE_KEYWORD_1:
-  case FALSE_KEYWORD_2:
-    return false;
-  case TRUE_KEYWORD_1:
-  case TRUE_KEYWORD_2:
-    return true;
-  default:
-    return value;
-  }
 }
 
 function mapBreakWith(value) {

--- a/lib/options/optimization-level.js
+++ b/lib/options/optimization-level.js
@@ -93,7 +93,7 @@ function optimizationLevelFrom(source) {
   }
 
   if (typeof source == 'object') {
-    source = covertValuesToHashes(source);
+    source = convertValuesToHashes(source);
   }
 
   if (One in source && 'roundingPrecision' in source[One]) {
@@ -169,7 +169,7 @@ function normalizeValue(value) {
   }
 }
 
-function covertValuesToHashes(source) {
+function convertValuesToHashes(source) {
   var clonedSource = override(source, {});
   var level;
   var i;
@@ -186,14 +186,14 @@ function covertValuesToHashes(source) {
     }
 
     if (level in clonedSource && typeof clonedSource[level] == 'string') {
-      clonedSource[level] = covertToHash(clonedSource[level], level);
+      clonedSource[level] = convertToHash(clonedSource[level], level);
     }
   }
 
   return clonedSource;
 }
 
-function covertToHash(asString, level) {
+function convertToHash(asString, level) {
   return asString
     .split(OPTION_SEPARATOR)
     .reduce(function(accumulator, directive) {

--- a/lib/options/optimization-level.js
+++ b/lib/options/optimization-level.js
@@ -1,6 +1,7 @@
 var roundingPrecisionFrom = require('./rounding-precision').roundingPrecisionFrom;
 
 var override = require('../utils/override');
+var normalizeValue = require('../utils/normalize-value');
 
 var OptimizationLevel = {
   Zero: '0',
@@ -53,10 +54,6 @@ DEFAULTS[OptimizationLevel.Two] = {
 
 var ALL_KEYWORD_1 = '*';
 var ALL_KEYWORD_2 = 'all';
-var FALSE_KEYWORD_1 = 'false';
-var FALSE_KEYWORD_2 = 'off';
-var TRUE_KEYWORD_1 = 'true';
-var TRUE_KEYWORD_2 = 'on';
 
 var LIST_VALUE_SEPARATOR = ',';
 var OPTION_SEPARATOR = ';';
@@ -154,19 +151,6 @@ function defaults(level, value) {
   }
 
   return options;
-}
-
-function normalizeValue(value) {
-  switch (value) {
-  case FALSE_KEYWORD_1:
-  case FALSE_KEYWORD_2:
-    return false;
-  case TRUE_KEYWORD_1:
-  case TRUE_KEYWORD_2:
-    return true;
-  default:
-    return value;
-  }
 }
 
 function convertValuesToHashes(source) {

--- a/lib/utils/normalize-value.js
+++ b/lib/utils/normalize-value.js
@@ -1,0 +1,19 @@
+var FALSE_KEYWORD_1 = 'false';
+var FALSE_KEYWORD_2 = 'off';
+var TRUE_KEYWORD_1 = 'true';
+var TRUE_KEYWORD_2 = 'on';
+
+function normalizeValue(value) {
+  switch (value) {
+  case FALSE_KEYWORD_1:
+  case FALSE_KEYWORD_2:
+    return false;
+  case TRUE_KEYWORD_1:
+  case TRUE_KEYWORD_2:
+    return true;
+  default:
+    return value;
+  }
+}
+
+module.exports = normalizeValue;


### PR DESCRIPTION
Technically speaking, the original poster had a typo in their format option, but this should fix the actual bug of string options to format not being parsed correctly.

Passes all test cases; works on my test file.