### PR TITLE
fix: dynamically require os for edge runtime compatibility

### DIFF
--- a/lib/options/format.js
+++ b/lib/options/format.js
@@ -1,6 +1,15 @@
-var systemLineBreak = require('os').EOL;
-
 var override = require('../utils/override');
+
+function getSystemLineBreak() {
+  var systemLinkBreak = '\n';
+  try {
+    var os = (globalThis.require ? require : function(){})('os');
+    systemLinkBreak = os.EOL;
+  } catch (_) {
+    // no op
+  }
+  return systemLinkBreak;
+}
 
 var Breaks = {
   AfterAtRule: 'afterAtRule',
@@ -17,7 +26,7 @@ var Breaks = {
 var BreakWith = {
   CarriageReturnLineFeed: '\r\n',
   LineFeed: '\n',
-  System: systemLineBreak
+  System: getSystemLineBreak()
 };
 
 var IndentWith = {
@@ -193,7 +202,7 @@ function mapBreakWith(value) {
   case BreakWith.LineFeed:
     return BreakWith.LineFeed;
   default:
-    return systemLineBreak;
+    return BreakWith.System;
   }
 }
 


### PR DESCRIPTION
This essentially makes `require('os')` dynamic for edge worker runtime compatibility (https://github.com/shellscape/jsx-email/issues/82#issuecomment-1824868899). The require of `os` as it currently is in master can be polyfilled away but requires use knowledge about bundlers and the correct way to bundle the package, if used directly, and any consumers of clean-css if used as a transitive dependency. Bundling is a minefield for most folks, and this should provide some relief. 