### PR TITLE
docs: README: typo: bufer -> buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,8 +905,8 @@ function css() {
     return src('app/**/*.css')
         .pipe(concat('style.min.css'))
         .on('data', function(file) {
-            const buferFile = new CleanCSS(options).minify(file.contents)
-            return file.contents = Buffer.from(buferFile.styles)
+            const bufferFile = new CleanCSS(options).minify(file.contents)
+            return file.contents = Buffer.from(bufferFile.styles)
         })
         .pipe(dest('build'))
 }


### PR DESCRIPTION
`bufer -> buffer`